### PR TITLE
Mirespace fix signing package building

### DIFF
--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -45,7 +45,7 @@ From within the package repository:
 
 ### Signing the Changes File
 
-In order for a source package to be accepted by Launchpad, it must be signed. You can build the sources using `git-ubuntu` with the `--sign` flag, or you can sign it manually with `debsign`:
+In order for a source package to be accepted by Launchpad, it must be signed. You can sign it manually with `debsign`:
 
     debsign $(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
 

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -45,9 +45,9 @@ From within the package repository:
 
 ### Signing the Changes File
 
-In order for a source package to be accepted by Launchpad, it must be signed. You can sign it manually with `debsign`:
+In order for a source package to be accepted by Launchpad, it must be signed. You can sign it manually with `debsign` (within the package folder):
 
-    debsign $(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
+    debsign ../$(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
 
 
 


### PR DESCRIPTION
Hi team,

I found a reference to the former option --sign of git-ubuntu (I suppose is from git ubuntu build-source that is no longer available).
I made a few changes that reflect that and also a fix for using the command as copy-paste directly.

Thanks!