### PR TITLE
Mirespace concepts link page not found

### DIFF
--- a/Concepts.md
+++ b/Concepts.md
@@ -351,7 +351,7 @@ This will attempt to clone the `hello` Ubuntu source code repository into a subd
      * [new tag]         upstream/debian/2.2.gz         -> pkg/upstream/debian/2.2.gz
      * [new tag]         upstream/debian/2.4.gz         -> pkg/upstream/debian/2.4.gz
 
-The branches you'll be interested in are `ubuntu/somerelease-devel`. `ubuntu/somerelease` is the package set as it was on release day. The `-devel` branch is that release plus all changes to date. The special `ubuntu-devel` branch points to the (unreleased) leading edge of development for the package in Ubuntu.
+The branches you'll be interested in are `ubuntu/somerelease-devel`. `ubuntu/somerelease` is the package set as it was on release day. The `-devel` branch is that release plus all changes to date. The special `ubuntu/devel` branch points to the (unreleased) leading edge of development for the package in Ubuntu.
 
 You'll be using the `-devel` branches for your changes.
 

--- a/Concepts.md
+++ b/Concepts.md
@@ -413,4 +413,4 @@ See Also
 
 https://www.debian.org/doc/debian-policy/
 
-http://people.canonical.com/~cjwatson/ubuntu-policy/
+apt install ubuntu-policy 


### PR DESCRIPTION
Hi team,

The page http://people.canonical.com/~cjwatson/ubuntu-policy/ is no longer available. As the ubuntu-policy is available via deb, maybe it can be a chance to get into it.

Also, I think there is a typo error for the special branch ubuntu/devel.

Please, review, and let me know (when it fits you well, of course!).

Thanks!